### PR TITLE
Fix for no global coffeescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "main": "./lib/index",
   "dependencies": {
+    "coffee-script": "~1.7.1",
     "event-stream": "~3.1.5",
     "bufferstreams": "0.0.2",
     "gulp-util": "~2.2.14"
@@ -28,7 +29,6 @@
   "devDependencies": {
     "mocha": "~1.18.2",
     "gulp": "~3.6.2",
-    "coffee-script": "~1.7.1",
     "should": "~3.3.1",
     "sinon": "~1.9.1",
     "proxyquire": "~0.6.0",


### PR DESCRIPTION
This fixes a proper run of the postinstall script in case the target system does not have coffeescript installed globally
