### PR TITLE
Added in enhanced syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ gulp.task('my-rewrite', function() {
 * `destination` (required) - the target directory for the processed CSS. Paths are rewritten relatively to that directory.
 * `[debug]` (optional, defaults to false) - whether to log what gulp-rewrite-css is doing
 
+#### Advanced Usage
+
+If you know exactly how you want your URLs rewritten, the following alternate syntax is allowed:
+
+* `enhanced.re` (required) - a [RegExp](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) object.  It will be matched against the bare URL (url() and quotes are stripped)
+* `enhanced.subst` (required) - the substitution string for the eventual call to [String.prototype.replace()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace).
+
 ## License
 
 MIT (c) 2015 Joscha Feth <joscha@feth.com>

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "scripts": {
     "prepublish": "./node_modules/coffee-script/bin/coffee -o lib/ src/",
+    "postinstall": "./node_modules/coffee-script/bin/coffee -o lib/ src/",
     "test": "mocha --compilers coffee:coffee-script/register -R spec",
     "watch": "mocha --compilers coffee:coffee-script/register -R min --watch",
     "coverage": "coffee -o src/ src/ && coffee -o test/ test/ && istanbul cover node_modules/.bin/_mocha --report html -- -R spec -t 3000 -s 2000",

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -51,7 +51,7 @@ module.exports = (opt) ->
       ret = match
       file = cleanMatch file
       if opt.enhanced?
-        ret = 'url("' + file.replace(opt.enhanced.re, opt.enhanced.subst) + '")'
+        ret = 'url(\'' + file.replace(opt.enhanced.re, opt.enhanced.subst) + '\')'
         if opt.debug
           gutil.log (magenta PLUGIN_NAME), 
                     'rewriting path for', 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -4,6 +4,7 @@ es = require 'event-stream'
 BufferStreams = require 'bufferstreams'
 gutil = require 'gulp-util'
 magenta = gutil.colors.magenta
+green = gutil.colors.green
 path = require 'path'
 url = require 'url'
 
@@ -35,7 +36,12 @@ module.exports = (opt) ->
   opt ?= {}
   opt.debug ?= false
 
-  unless opt.destination
+  if opt.enhanced?
+    unless opt.enhanced?.re && opt.enhanced.re instanceof RegExp
+      throw new gutil.PluginError PLUGIN_NAME, 'enhanced.re must be an instance of RegExp'
+    unless opt.enhanced.subst?
+      throw new gutil.PluginError PLUGIN_NAME, 'enhanced.subst must be specified'
+  else unless opt.destination
     throw new gutil.PluginError PLUGIN_NAME, 'destination directory is mssing'
 
   rewriteUrls = (sourceFilePath, data) ->
@@ -44,26 +50,38 @@ module.exports = (opt) ->
     data.replace URL_REGEX, (match, file) ->
       ret = match
       file = cleanMatch file
-      if (isRelativeUrl file) and not (isRelativeToBase file)
-        targetUrl = path.join (path.relative destinationDir, sourceDir), file
-        # fix for windows paths
-        targetUrl = targetUrl.replace ///\\///g, '/' if path.sep is '\\'
-        ret = """url("#{targetUrl.replace('"', '\\"')}")"""
+      if opt.enhanced?
+        ret = 'url("' + file.replace(opt.enhanced.re, opt.enhanced.subst) + '")'
         if opt.debug
-          gutil.log (magenta PLUGIN_NAME),
-                    'rewriting path for',
-                    (magenta match),
-                    'in',
-                    (magenta sourceFilePath),
+          gutil.log (magenta PLUGIN_NAME), 
+                    'rewriting path for', 
+                    (magenta file),
                     'to',
-                    (magenta ret)
-      else
-        if opt.debug
-          gutil.log (magenta PLUGIN_NAME),
-                    'not rewriting absolute path for',
-                    (magenta match),
+                    (magenta ret),
                     'in',
-                    (magenta sourceFilePath)
+                    (green sourceFilePath)
+
+      else 
+        if (isRelativeUrl file) and not (isRelativeToBase file)
+          targetUrl = path.join (path.relative destinationDir, sourceDir), file
+          # fix for windows paths
+          targetUrl = targetUrl.replace ///\\///g, '/' if path.sep is '\\'
+          ret = """url("#{targetUrl.replace('"', '\\"')}")"""
+          if opt.debug
+            gutil.log (magenta PLUGIN_NAME),
+                      'rewriting path for',
+                      (magenta match),
+                      'in',
+                      (magenta sourceFilePath),
+                      'to',
+                      (magenta ret)
+        else
+          if opt.debug
+            gutil.log (magenta PLUGIN_NAME),
+                      'not rewriting absolute path for',
+                      (magenta match),
+                      'in',
+                      (magenta sourceFilePath)
       ret
 
   bufferReplace = (file, data) ->

--- a/test/fixtures/index.enhanced.css
+++ b/test/fixtures/index.enhanced.css
@@ -1,0 +1,8 @@
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src:  local('Open Sans'),
+        local('OpenSans'),
+        url(fonts/OpenSans.woff) format('woff');
+}

--- a/test/fixtures/index.enhanced.expected.css
+++ b/test/fixtures/index.enhanced.expected.css
@@ -1,0 +1,8 @@
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 400;
+  src:  local('Open Sans'),
+        local('OpenSans'),
+        url('fonts/ArbitraryReplacement.woff') format('woff');
+}

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -175,3 +175,24 @@ describe 'gulp-rewrite-css', ->
         assert 'index.windows.css',
                 done,
                 'index.windows.expected.css'
+
+  describe 'with enhanced syntax', ->
+
+    beforeEach -> 
+      opts = 
+        enhanced:
+          re: /OpenSans/
+          subst: 'ArbitraryReplacement'
+
+      inFile = getFixturePath 'index.enhanced.css'
+      expected = loadFixture 'index.enhanced.expected.css'
+
+    assert = (done) ->
+      gulp.src(inFile)
+        .pipe(rewriteCss(opts))
+        .pipe es.map (file)->
+          file.contents.toString().should.eql expected 
+          done()
+
+    it 'should rewrite the name of the font to "ArbitraryReplacement"', (done)->
+      assert(done)


### PR DESCRIPTION
I found the current system too limiting for the rewriting that I wanted to do.  This patch implements an enhanced syntax that allows one to specify the exact regular expression replacement to be used.