### PR TITLE
Update URL regex to account for comma after the URL

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -16,7 +16,7 @@ URL_REGEX = ///
             \(  # An opening bracket
             \s* # Arbitrary white-spaces
             (?!["']?data:) # explicitly don't match data-urls
-            (.+?)\)(?=\s+(?!\))|;|}) # anything up to first closing bracket that is not followed by other closing brackets
+            (.+?)\)(?=\s+(?!\))|;|}|,) # anything up to first closing bracket that is not followed by other closing brackets
             ///g # We want to replace all the matches
 
 IMPORT_REGEX = ///

--- a/test/fixtures/comma.css
+++ b/test/fixtures/comma.css
@@ -1,0 +1,3 @@
+.baz {
+  cursor: url(hyper.cur), auto;
+}

--- a/test/fixtures/comma.expected.css
+++ b/test/fixtures/comma.expected.css
@@ -1,0 +1,3 @@
+.baz {
+  cursor: url("../../hyper.cur"), auto;
+}

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -220,3 +220,12 @@ describe 'gulp-rewrite-css', ->
 
     it 'should rewrite urls in minified css', (done) ->
       assert 'minified.css', done, 'minified.expected.css'
+
+  describe 'comma after URLs', ->
+    beforeEach ->
+      opts =
+        destination: getFixturePath 'another/dir'
+
+    it 'should rewrite URLs that are followed by a comma', (done) ->
+      assert 'comma.css', done, 'comma.expected.css'
+


### PR DESCRIPTION
The spec for the cursor CSS property (https://developer.mozilla.org/en-US/docs/Web/CSS/cursor) has examples where a url is followed by a comma. For example:

`.baz {
  cursor: url(hyper.cur), auto;
}`

This change adds comma to the regex that ends a url().