### PR TITLE
Migrate away from gulp-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,12 @@
   ],
   "main": "./lib/index",
   "dependencies": {
-    "event-stream": "~3.3.2",
+    "ansi-green": "^0.1.1",
+    "ansi-magenta": "^0.1.1",
     "bufferstreams": "~2.0.0",
-    "gulp-util": "~3.0.6"
+    "event-stream": "~3.3.2",
+    "fancy-log": "^1.3.2",
+    "plugin-error": "^1.0.0"
   },
   "engines": {
     "node": ">= 4"
@@ -43,7 +46,8 @@
     "should": "~13.1.0",
     "sinon": "~4.1.0",
     "strip-ansi": "~3.0.0",
-    "semantic-release": "^7.0.1"
+    "semantic-release": "^7.0.1",
+    "vinyl": "^1.2.0"
   },
   "license": "MIT",
   "config": {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -2,9 +2,10 @@
 
 es = require 'event-stream'
 BufferStreams = require 'bufferstreams'
-gutil = require 'gulp-util'
-magenta = gutil.colors.magenta
-green = gutil.colors.green
+magenta = require 'ansi-magenta'
+green = require 'ansi-green'
+PluginError = require 'plugin-error'
+log = require 'fancy-log'
 path = require 'path'
 url = require 'url'
 
@@ -49,10 +50,10 @@ module.exports = (opt) ->
   opt.adaptPath ?= adaptPath
 
   unless typeof opt.adaptPath is 'function'
-    throw new gutil.PluginError PLUGIN_NAME, 'adaptPath method is missing'
+    throw new PluginError PLUGIN_NAME, 'adaptPath method is missing'
 
   unless opt.destination
-    throw new gutil.PluginError PLUGIN_NAME, 'destination directory is missing'
+    throw new PluginError PLUGIN_NAME, 'destination directory is missing'
 
   mungePath = (match, sourceFilePath, file) ->
     if (isRelativeUrl file) and not (isRelativeToBase file)
@@ -69,7 +70,7 @@ module.exports = (opt) ->
         targetUrl = targetUrl.replace ///\\///g, '/' if path.sep is '\\'
         return targetUrl.replace "'", "\\'"
     else if opt.debug
-      gutil.log (magenta PLUGIN_NAME),
+      log (magenta PLUGIN_NAME),
                 'not rewriting absolute path for',
                 (magenta match),
                 'in',
@@ -78,7 +79,7 @@ module.exports = (opt) ->
 
   logRewrite = (match, sourceFilePath, destinationFilePath) ->
     if opt.debug
-      gutil.log (magenta PLUGIN_NAME),
+      log (magenta PLUGIN_NAME),
                 'rewriting path for',
                 (magenta match),
                 'in',
@@ -108,7 +109,7 @@ module.exports = (opt) ->
 
   streamReplace = (file) ->
     (err, buf, cb) ->
-      cb gutil.PluginError PLUGIN_NAME, err if err
+      cb PluginError PLUGIN_NAME, err if err
 
       # Use the buffered content
       buf = Buffer bufferReplace file, String buf

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -6,14 +6,16 @@ proxyquire = require 'proxyquire'
 gutilStub =
   log: ->
     #console.log(arguments)
+fancyLogStub = ->
+  gutilStub.log.apply(null, arguments)
 path = require 'path'
 rewriteCss = proxyquire '../src',
-  'gulp-util': gutilStub
+  'fancy-log': fancyLogStub
   'path': path
 es = require 'event-stream'
 Stream = require 'stream'
 fs = require 'fs'
-gutil = require 'gulp-util'
+Vinyl = require 'vinyl'
 stripAnsi = require 'strip-ansi'
 
 getFixturePath = (relativePath = '') ->
@@ -70,7 +72,7 @@ describe 'gulp-rewrite-css', ->
 
   describe 'with null file', ->
     it 'should return the file as-is', (done) ->
-      file = new gutil.File
+      file = new Vinyl
         base: getFixturePath()
         cwd: __dirname,
         path: inFile


### PR DESCRIPTION
gulp-util is deprecated. This migrates to using the underlying packages directly. See https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5