### PR TITLE
Migrate to the latest version of semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,7 @@ notifications:
   email: false
 node_js:
   - 'stable'
-  - '5'
-  - '4'
-before_install:
-  - npm i -g npm@^2.0.0
+  - '8'
 before_script:
   - npm prune
 after_success:
@@ -18,7 +15,7 @@ after_success:
   - 'curl -Lo travis_after_all.py https://git.io/travis_after_all'
   - python travis_after_all.py
   - export $(cat .to_export_back) &> /dev/null
-  - npm run semantic-release
+  - npm run travis-deploy-once "npm run semantic-release"
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "watch": "mocha --compilers coffee:coffee-script/register -R min --watch",
     "coverage": "coffee -o src src && coffee -o test test && istanbul cover _mocha --report html -- -R spec -t 3000 -s 2000",
     "coveralls": "coffee -o src src && coffee -o test test && istanbul cover _mocha --report lcovonly -- -R spec -t 3000 -s 2000 && cat ./coverage/lcov.info | coveralls",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release",
+    "travis-deploy-once": "travis-deploy-once"
   },
   "files": [
     "lib"
@@ -43,7 +44,8 @@
     "should": "~13.1.0",
     "sinon": "~4.1.0",
     "strip-ansi": "~3.0.0",
-    "semantic-release": "^7.0.1"
+    "semantic-release": "^12.2.3",
+    "travis-deploy-once": "^4.3.2"
   },
   "license": "MIT",
   "config": {


### PR DESCRIPTION
This replaces #85, by doing the necessary migration steps.