### PR TITLE
Fix to address event-stream vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "ansi-green": "^0.1.1",
     "ansi-magenta": "^0.1.1",
     "bufferstreams": "~2.0.0",
-    "event-stream": "~3.3.2",
+    "event-stream": "3.3.4",
     "fancy-log": "^1.3.2",
     "plugin-error": "^1.0.0"
   },


### PR DESCRIPTION
Locked `event-stream` package to `3.3.4` before the compromise.
See: blog.npmjs.org/post/180565383195/details-about-the-event-stream-incident